### PR TITLE
Fix IE11 classList.add()

### DIFF
--- a/elements/alert/alert.js
+++ b/elements/alert/alert.js
@@ -13,8 +13,8 @@
         }
 
         this.setAttribute('role', 'alert');
-        this.classList.add("fade");
-        this.classList.add("show");
+        this.classList.add('fade');
+        this.classList.add('show');
 
         if (this['data-type'] && ['info', 'success', 'warning', 'danger'].indexOf(this['data-type']) > -1) {
             if (this['data-type'] === 'success') {


### PR DESCRIPTION
IE11 doesn't allow adding multiple classes in 1 instance of `add()`